### PR TITLE
A fix to match basic RFC requirments

### DIFF
--- a/example/redirect.go
+++ b/example/redirect.go
@@ -42,6 +42,8 @@ func toGolang(w icap.ResponseWriter, req *icap.Request) {
 	case "OPTIONS":
 		h.Set("Methods", "REQMOD")
 		h.Set("Allow", "204")
+		h.Set("Preview", "0")
+		h.Set("Transfer-Preview", "*")
 		w.WriteHeader(200, nil, false)
 	case "REQMOD":
 		switch req.Request.Host {


### PR DESCRIPTION
The example code until now doesn't implement any body handling related code but does allow it and it creates weird situation on runtime.
This addition uses the basic ICAP RFC preview settings and allow the ICAP service to not be required to handle the body of the http request.
Instead of handling the body, the settings instructs the ICAP client to send "0 size" preview of the http request body and by that allowing the server to be enabled to require a body but only when writing such a code.
The specific use cases are POST,PUT and other requests which includes request body and that this service breaks by not handling the body correctly.
